### PR TITLE
Fix a couple of minor erros in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ This library is 100% test covered 😁
 
 ## Features
 - [Levenshtein](https://en.wikipedia.org/wiki/Levenshtein_distance) ✨
-- [LCS](https://en.wikipedia.org/wiki/Levenshtein_distance) (Longest common subsequence) with edit distance, backtrack and diff functions ✨
+- [LCS](https://en.wikipedia.org/wiki/Longest_common_subsequence_problem) (Longest common subsequence) with edit distance, backtrack and diff functions ✨
 - [Hamming](https://en.wikipedia.org/wiki/Hamming_distance) ✨
 - [Damerau-Levenshtein](https://en.wikipedia.org/wiki/Damerau%E2%80%93Levenshtein_distance), with following variants :
     - OSA (Optimal string alignment) ✨
@@ -65,7 +65,7 @@ This library is 100% test covered 😁
 - And many more to come !
 
 ## Benchmarks
-You can check an interactive Google chart with few benchmark cases for all similarity algorithms in this library through **StringSimilarity** function [here](http://benchgraph.codingberg.com/q5)
+You can check an interactive Google chart with few benchmark cases for all similarity algorithms in this library through **StringsSimilarity** function [here](http://benchgraph.codingberg.com/q5)
 
 However, if you want or need more details, you can also viewing benchmark raw output [here](https://github.com/hbollon/go-edlib/blob/master/tests/outputs/benchmarks.txt), which also includes memory allocations and test cases output (similarity result and errors).
 


### PR DESCRIPTION
* Add an 's' in StringsSimilarity under Benchmarks
* Point to Longest common subsequence wikipedia page for LCS