### PR TITLE
reduce OSADamerau–Levenshtein space complexity from O(m*n) to O(3 * min(m*n))

### DIFF
--- a/levenshtein.go
+++ b/levenshtein.go
@@ -65,26 +65,25 @@ func OSADamerauLevenshteinDistance(str1, str2 string) int {
 		return runeStr1len
 	} else if utils.Equal(runeStr1, runeStr2) {
 		return 0
+	} else if runeStr1len < runeStr2len {
+		return OSADamerauLevenshteinDistance(str2, str1)
 	}
 
 	// 2D Array
-	matrix := make([][]int, runeStr1len+1)
-	for i := 0; i <= runeStr1len; i++ {
+	row := utils.Min(runeStr1len+1, 3)
+	matrix := make([][]int, row)
+	for i := 0; i < row; i++ {
 		matrix[i] = make([]int, runeStr2len+1)
-		for j := 0; j <= runeStr2len; j++ {
-			matrix[i][j] = 0
-		}
-	}
-
-	for i := 0; i <= runeStr1len; i++ {
 		matrix[i][0] = i
 	}
+
 	for j := 0; j <= runeStr2len; j++ {
 		matrix[0][j] = j
 	}
 
 	var count int
 	for i := 1; i <= runeStr1len; i++ {
+		matrix[i%3][0] = i
 		for j := 1; j <= runeStr2len; j++ {
 			if runeStr1[i-1] == runeStr2[j-1] {
 				count = 0
@@ -92,13 +91,14 @@ func OSADamerauLevenshteinDistance(str1, str2 string) int {
 				count = 1
 			}
 
-			matrix[i][j] = utils.Min(utils.Min(matrix[i-1][j]+1, matrix[i][j-1]+1), matrix[i-1][j-1]+count) // insertion, deletion, substitution
+			matrix[i%3][j] = utils.Min(utils.Min(matrix[(i-1)%3][j]+1, matrix[i%3][j-1]+1),
+				matrix[(i-1)%3][j-1]+count) // insertion, deletion, substitution
 			if i > 1 && j > 1 && runeStr1[i-1] == runeStr2[j-2] && runeStr1[i-2] == runeStr2[j-1] {
-				matrix[i][j] = utils.Min(matrix[i][j], matrix[i-2][j-2]+1) // translation
+				matrix[i%3][j] = utils.Min(matrix[i%3][j], matrix[(i-2)%3][j-2]+1) // translation
 			}
 		}
 	}
-	return matrix[runeStr1len][runeStr2len]
+	return matrix[runeStr1len%3][runeStr2len]
 }
 
 // DamerauLevenshteinDistance calculate the distance between two string


### PR DESCRIPTION
Hi,this is the pr for [issue](https://github.com/hbollon/go-edlib/issues/16).
I run the benchmark on OSADamerauLevenshtein.
Here is the result.
| name | before | after | alloc_before | alloc_after | 
| :-----:| :----: | :----: | :----: | :----: |
| sameLengthStringInput | 3389 ns/op |2416 ns/op |23 allocs/op |4 allocs/op |
| pneumonoultramicroscopi | 15462 ns/op|  10253 ns/op |51 allocs/op|  8 allocs/op |
|こにんちこにんちこに | 4027 ns/op |  3342 ns/op |18 allocs/op | 4 allocs/op|
| I_love_horror_movi |  4282 ns/op |  3073 ns/op | 22 allocs/op |  4 allocs/op |